### PR TITLE
Updates package.json to move react and react-native from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"
   },
-  "dependencies": {
-    "react": "15.4.2",
-    "react-native": "0.40.0"
+  "peerDependencies": {
+    "react": ">=15.4.0",
+    "react-native": ">=0.40"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",


### PR DESCRIPTION
## Overview

See #7.  The older version would break current versions of React Native (tested using RN 0.45.1) because of the specific, static dependencies definitions for `react` and `react-native`.

Grokked `react-native-maps`' package.json to make this library more permissive.